### PR TITLE
Support .zip files as well as .tar.gz

### DIFF
--- a/config/samples/sync.yaml
+++ b/config/samples/sync.yaml
@@ -3,7 +3,9 @@ kind: Sync
 metadata:
   name: sync
 spec:
-  url: "http://source-controller.system/gitrepository/default/source/latest.tar.gz"
+  url: "https://github.com/squaremo/flux-example/archive/master.zip"
+  # url: "http://source-controller.system/gitrepository/default/source/latest.tar.gz"
   paths:
-  - config/ollehworld
-  interval: 1m
+  - flux-example-master/config/ollehworld
+  # - config/ollehworld
+  interval: 2m


### PR DESCRIPTION
GitHub makes ZIP files available for repos, so you can now target a
Sync directly at a public GitHub repo.

This is more neat than useful, at present, but with a bit of caching
and rate-limiting, could be a handy shortcut.