### PR TITLE
Move site and condition for unready cluster sync

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,2 +1,8 @@
 resources:
 - manager.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+images:
+- name: controller
+  newName: squaremo/sync-controller
+  newTag: latest

--- a/controllers/syncgroup_controller.go
+++ b/controllers/syncgroup_controller.go
@@ -336,14 +336,7 @@ func partitionSyncs(syncs []syncv1alpha1.Sync, clusters []clusterv1alpha3.Cluste
 	var okSyncs []*syncv1alpha1.Sync
 
 	for _, c := range clusters {
-		// Only include it as a live cluster if it's provisioned and
-		// the control plane is ready and the infrastructure is ready;
-		// this is as close an indication as you get for a cluster
-		// that it is ready to be used, as far as I can tell.
-		if c.Status.GetTypedPhase() == clusterv1alpha3.ClusterPhaseProvisioned &&
-			c.Status.ControlPlaneReady && c.Status.InfrastructureReady {
-			clustersToSync[c.Name] = struct{}{}
-		}
+		clustersToSync[c.Name] = struct{}{}
 	}
 	for _, s := range syncs {
 		if s.Spec.Cluster == nil {


### PR DESCRIPTION
Previously: when calculating which syncs should exist, ignore clusters
that aren't ready. But this means you don't get a sync that can have
status; so,

Now: when considering a sync, if it's cluster isn't ready, skip it.

This also changes the condition from `controlPlaneReady` to
`controlPlaneInitialized`; empirically it seems that a cluster is
ready once it's passed the latter gate, while the ready flag may not
ever be set.